### PR TITLE
Introduce objective aggregation and restructure energy metrics

### DIFF
--- a/src/bagel/__init__.py
+++ b/src/bagel/__init__.py
@@ -14,7 +14,7 @@ __version__ = get_version_from_pyproject()
 from .chain import Chain, Residue
 from .state import State
 from .system import System
-from . import constants, energies, minimizer, mutation, oracles
+from . import constants, energies, minimizer, mutation, objectives, oracles
 
 
-__all__ = ['Chain', 'Residue', 'State', 'System', 'constants', 'energies', 'minimizer', 'mutation', 'oracles']
+__all__ = ['Chain', 'Residue', 'State', 'System', 'constants', 'energies', 'minimizer', 'mutation', 'objectives', 'oracles']

--- a/src/bagel/minimizer.py
+++ b/src/bagel/minimizer.py
@@ -9,6 +9,7 @@ Copyright (c) 2025 Jakub Lála, Ayham Al-Saffar, Stefano Angioletti-Uberti
 import pathlib as pl
 from .system import System
 from .mutation import MutationProtocol
+from .objectives import DEFAULT_OBJECTIVE_ID
 from abc import ABC, abstractmethod
 from typing import Callable, Any
 import numpy as np
@@ -188,7 +189,7 @@ class MonteCarloMinimizer(Minimizer):
 
     def minimize_system(self, system: System) -> System:
         """Minimize system using Monte Carlo method."""
-        system.get_total_energy()  # update the energy internally
+        system.evaluate([DEFAULT_OBJECTIVE_ID])  # update the energy internally
         best_system = system.__copy__()
         assert system.total_energy is not None, 'Cannot start without system having a calculated energy'
         assert best_system.total_energy is not None, (

--- a/src/bagel/objectives.py
+++ b/src/bagel/objectives.py
@@ -1,0 +1,73 @@
+"""Objective and constraint specifications for BAGEL energy aggregation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Literal, Sequence
+
+AggregationRule = Literal['sum', 'max', 'delta']
+
+
+def aggregate_values(values: Iterable[float], rule: AggregationRule) -> float:
+    """Aggregate ``values`` according to ``rule``.
+
+    Parameters
+    ----------
+    values:
+        Iterable of numeric values to aggregate.
+    rule:
+        Aggregation rule to apply. ``'sum'`` performs an arithmetic sum, ``'max'``
+        returns the maximum value, while ``'delta'`` computes a signed
+        difference between the first element and the sum of the remaining
+        elements. Empty collections return ``0.0`` for all rules.
+    """
+
+    collected = list(values)
+    if not collected:
+        return 0.0
+
+    if rule == 'sum':
+        return float(sum(collected))
+    if rule == 'max':
+        return float(max(collected))
+    if rule == 'delta':
+        head, *tail = collected
+        return float(head - sum(tail))
+    raise ValueError(f'Unsupported aggregation rule: {rule}')
+
+
+@dataclass(frozen=True)
+class ConstraintSpec:
+    """Defines how a constraint metric should be aggregated and weighted."""
+
+    constraint_id: str
+    aggregation: AggregationRule = 'delta'
+    weight: float = 1.0
+    states: Sequence[str] | None = None
+
+
+@dataclass(frozen=True)
+class ObjectiveSpec:
+    """Configuration for aggregating an objective across energy terms/states."""
+
+    objective_id: str
+    aggregation: AggregationRule = 'sum'
+    weight: float = 1.0
+    constraints: Sequence[ConstraintSpec] = field(default_factory=tuple)
+
+
+DEFAULT_OBJECTIVE_ID = 'total_energy'
+
+
+def default_objective_spec() -> ObjectiveSpec:
+    """Return a fresh :class:`ObjectiveSpec` for the legacy total energy."""
+
+    return ObjectiveSpec(objective_id=DEFAULT_OBJECTIVE_ID, aggregation='sum', weight=1.0)
+
+
+def default_objective_specs() -> dict[str, ObjectiveSpec]:
+    """Return the default mapping of objective specifications."""
+
+    spec = default_objective_spec()
+    return {spec.objective_id: spec}
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pathlib as pl
 from biotite.structure import AtomArray, Atom, array, concatenate
 from biotite.structure.io import load_structure
 import bagel as bg
+from bagel.objectives import DEFAULT_OBJECTIVE_ID
 
 
 def pytest_addoption(parser):
@@ -212,8 +213,8 @@ def small_structure_state(
         local_plddt=np.zeros(len(small_structure))[None, :],
     )
     state._energy_terms_value = {
-        energy_terms[0].name: -0.7,
-        energy_terms[1].name: 0.2,
+        energy_terms[0].name: {'objectives': {DEFAULT_OBJECTIVE_ID: -0.7}},
+        energy_terms[1].name: {'objectives': {DEFAULT_OBJECTIVE_ID: 0.2}},
     }
     state._oracles_result = bg.oracles.OraclesResultDict()
     state._oracles_result[state.oracles_list[0]] = folding_result
@@ -413,8 +414,8 @@ def mixed_structure_state(
     )
     state._energy = 0.1
     state._energy_terms_value = {
-        energy_terms[0].name: -0.4,
-        energy_terms[1].name: 0.5,
+        energy_terms[0].name: {'objectives': {DEFAULT_OBJECTIVE_ID: -0.4}},
+        energy_terms[1].name: {'objectives': {DEFAULT_OBJECTIVE_ID: 0.5}},
     }
     state._oracles_result = bg.oracles.OraclesResultDict()
     state._oracles_result[state.oracles_list[0]] = folding_result
@@ -482,8 +483,8 @@ def simple_state(fake_esmfold: bg.oracles.folding.ESMFold) -> bg.State:
     )
     state._structure = AtomArray(length=len(residues))
     state._energy_terms_value = {
-        state.energy_terms[0].name: -1.0,
-        state.energy_terms[1].name: -0.5,
+        state.energy_terms[0].name: {'objectives': {DEFAULT_OBJECTIVE_ID: -1.0}},
+        state.energy_terms[1].name: {'objectives': {DEFAULT_OBJECTIVE_ID: -0.5}},
     }
     return state
 


### PR DESCRIPTION
## Summary
- add `bagel.objectives` to define objective and constraint specifications plus aggregation helpers
- update energy terms, state aggregation, and system evaluation/logging to produce per-objective metrics while keeping the legacy total energy
- migrate mutation/minimizer workflows and unit tests to the multi-objective interface and add regression coverage for delta constraints

## Testing
- `pytest tests/unit_tests -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68da855c293c832e8fc820997235356d